### PR TITLE
fix scan_session number formatting download_oasis_scans_bids.sh

### DIFF
--- a/download_scans/download_oasis_scans_bids.sh
+++ b/download_scans/download_oasis_scans_bids.sh
@@ -141,6 +141,9 @@ function move_to_bids () {
             # d0129
             scan_session=`echo $scan_session_ses | cut -d- -f2`
 
+            # ensure 4 digits formatting in scan_session
+            scan_session="${scan_session/${scan_session:1}/$(printf "%04d" "${scan_session:1}")}"
+
             # Create the folder structure based on the labels gathered
             subject_folder=sub-${scan_subject}
             session_folder=ses-${scan_session}


### PR DESCRIPTION
some numbers in scan_session is not in 4 digits format, this command fix that